### PR TITLE
fix: support path-based multi-tenancy

### DIFF
--- a/app/[[...path]]/page.tsx
+++ b/app/[[...path]]/page.tsx
@@ -12,11 +12,11 @@ export default async function Page({ params }: { params: Promise<{ path?: string
   if (pathSegments.length === 0) return notFound()
 
   // First segment is the subdomain (siteA, siteB, etc.)
-  const subdomain = pathSegments.at(0) ?? 'default'
+  const subdomainFromPath = pathSegments.at(0) ?? 'default'
   const remainingPath = pathSegments.slice(1)
   const makeswiftPath = '/' + remainingPath.join('/')
 
-  const makeswiftClient = new Makeswift(getApiKey(subdomain), {
+  const makeswiftClient = new Makeswift(getApiKey(subdomainFromPath), {
     runtime,
   })
 

--- a/app/api/makeswift/[...makeswift]/route.ts
+++ b/app/api/makeswift/[...makeswift]/route.ts
@@ -5,16 +5,16 @@ import { MakeswiftApiHandler } from '@makeswift/runtime/next/server'
 
 import '@/lib/makeswift/components'
 import { runtime } from '@/lib/makeswift/runtime'
-import { getApiKey, getSubdomainFromHost } from '@/lib/makeswift/tenants'
+import { DEFAULT_TENANT_ID, getApiKey, getSubdomainFromHost } from '@/lib/makeswift/tenants'
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const headersList = await headers()
   const host = headersList.get('host') ?? ''
 
   // Get the subdomain from the host (e.g., "siteA" from "siteA.localhost:3000")
-  const subdomain = getSubdomainFromHost(host)
+  const tenantIdFromSubdomain = getSubdomainFromHost(host)
 
-  const apiKey = getApiKey(subdomain)
+  const apiKey = getApiKey(tenantIdFromSubdomain ?? DEFAULT_TENANT_ID)
 
   return await MakeswiftApiHandler(apiKey, { runtime })(req, res)
 }

--- a/lib/makeswift/tenants.ts
+++ b/lib/makeswift/tenants.ts
@@ -25,5 +25,10 @@ export function isValidTenantId(subdomain: string) {
 }
 
 export function getSubdomainFromHost(host: string): string | null {
-  return host.split('.').at(0) ?? null
+  const parts = host.split('.')
+  // A valid subdomain requires at least 2 parts: subdomain.domain
+  if (parts.length < 2) {
+    return null
+  }
+  return parts[0]
 }

--- a/lib/makeswift/tenants.ts
+++ b/lib/makeswift/tenants.ts
@@ -1,7 +1,9 @@
 import { env } from 'env'
 
+export const DEFAULT_TENANT_ID = 'default'
+
 const SUBDOMAIN_TO_API_KEY = {
-  default: env.DEFAULT_MAKESWIFT_SITE_API_KEY,
+  [DEFAULT_TENANT_ID]: env.DEFAULT_MAKESWIFT_SITE_API_KEY,
   [env.SITE_A_SUBDOMAIN]: env.SITE_A_MAKESWIFT_SITE_API_KEY,
   [env.SITE_B_SUBDOMAIN]: env.SITE_B_MAKESWIFT_SITE_API_KEY,
 }
@@ -22,10 +24,6 @@ export function isValidTenantId(subdomain: string) {
   return subdomain in SUBDOMAIN_TO_API_KEY
 }
 
-export function getSubdomainFromHost(host: string): string {
-  if (!host.includes('.')) {
-    return 'default'
-  }
-
-  return host.split('.').at(0) ?? 'default'
+export function getSubdomainFromHost(host: string): string | null {
+  return host.split('.').at(0) ?? null
 }


### PR DESCRIPTION
Support direct visits to root domain/{tenantId}/... by checking if first path segment is already a valid tenant ID when a subdomain is not present.